### PR TITLE
Issue #4: YouTube OAuth2 uploader (resumable + scheduling)

### DIFF
--- a/TubePilot/TubePilot.Core/Contracts/IYouTubeUploader.cs
+++ b/TubePilot/TubePilot.Core/Contracts/IYouTubeUploader.cs
@@ -1,0 +1,30 @@
+namespace TubePilot.Core.Contracts;
+
+public interface IYouTubeUploader
+{
+    Task<YouTubeUploadResult> UploadAsync(
+        YouTubeUploadRequest request,
+        Func<int, Task> progressCallback,
+        CancellationToken ct = default);
+}
+
+public sealed record YouTubeUploadRequest(
+    string VideoFilePath,
+    string Title,
+    string Description,
+    IReadOnlyList<string>? Tags = null,
+    DateTimeOffset? ScheduledPublishAtUtc = null,
+    string? ThumbnailFilePath = null,
+    string? CategoryId = null);
+
+public enum YouTubeUploadStatus
+{
+    Published,
+    Scheduled
+}
+
+public sealed record YouTubeUploadResult(
+    string VideoId,
+    string YouTubeUrl,
+    YouTubeUploadStatus Status,
+    DateTimeOffset? ScheduledAtUtc);

--- a/TubePilot/TubePilot.Infrastructure.Tests/YouTubeUploaderTests.cs
+++ b/TubePilot/TubePilot.Infrastructure.Tests/YouTubeUploaderTests.cs
@@ -1,0 +1,177 @@
+using System.Net;
+using System.Text.Json;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using TubePilot.Core.Contracts;
+using TubePilot.Infrastructure.YouTube;
+using TubePilot.Infrastructure.YouTube.Options;
+
+namespace TubePilot.Infrastructure.Tests;
+
+public sealed class OAuthRefreshTokenAccessTokenProviderTests
+{
+    [Fact]
+    public async Task GetAccessTokenAsync_RefreshesAndCachesToken()
+    {
+        var handler = new RecordingHandler(async request =>
+        {
+            Assert.Equal(HttpMethod.Post, request.Method);
+            Assert.Equal("https://oauth2.googleapis.com/token", request.RequestUri!.ToString());
+
+            var body = await request.Content!.ReadAsStringAsync();
+            var form = FormEncoding.ParseFormUrlEncoded(body);
+
+            Assert.Equal("client-id", form["client_id"]);
+            Assert.Equal("client-secret", form["client_secret"]);
+            Assert.Equal("refresh-token", form["refresh_token"]);
+            Assert.Equal("refresh_token", form["grant_type"]);
+
+            return new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent("""{"access_token":"ya29.test","expires_in":3600}""")
+            };
+        });
+
+        var httpClient = new HttpClient(handler);
+        var optionsMonitor = new StaticOptionsMonitor<YouTubeOptions>(new YouTubeOptions
+        {
+            ClientId = "client-id",
+            ClientSecret = "client-secret",
+            RefreshToken = "refresh-token"
+        });
+
+        var provider = new OAuthRefreshTokenAccessTokenProvider(
+            httpClient,
+            optionsMonitor,
+            NullLogger<OAuthRefreshTokenAccessTokenProvider>.Instance);
+
+        var token1 = await provider.GetAccessTokenAsync(CancellationToken.None);
+        var token2 = await provider.GetAccessTokenAsync(CancellationToken.None);
+
+        Assert.Equal("ya29.test", token1);
+        Assert.Equal("ya29.test", token2);
+        Assert.Equal(1, handler.CallCount);
+    }
+}
+
+public sealed class YouTubeUploaderRequestBuildingTests
+{
+    [Fact]
+    public async Task UploadAsync_WhenScheduled_SetsPrivateAndPublishAt()
+    {
+        string? initiateJson = null;
+
+        var handler = new RecordingHandler(async request =>
+        {
+            if (request.Method == HttpMethod.Post &&
+                request.RequestUri!.ToString().Contains("/upload/youtube/v3/videos", StringComparison.Ordinal))
+            {
+                initiateJson = await request.Content!.ReadAsStringAsync();
+
+                var response = new HttpResponseMessage(HttpStatusCode.OK);
+                response.Headers.Location = new Uri("https://upload.test/session");
+                return response;
+            }
+
+            if (request.Method == HttpMethod.Put && request.RequestUri!.ToString() == "https://upload.test/session")
+            {
+                return new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent("""{"id":"video123"}""")
+                };
+            }
+
+            return new HttpResponseMessage(HttpStatusCode.NotFound)
+            {
+                Content = new StringContent("""{"error":"unexpected request"}""")
+            };
+        });
+
+        var httpClient = new HttpClient(handler);
+        var tokenProvider = new StubAccessTokenProvider("access-token");
+        var optionsMonitor = new StaticOptionsMonitor<YouTubeOptions>(new YouTubeOptions { DefaultCategoryId = "22" });
+
+        var uploader = new YouTubeUploader(
+            httpClient,
+            tokenProvider,
+            optionsMonitor,
+            NullLogger<YouTubeUploader>.Instance);
+
+        var scheduledAt = new DateTimeOffset(2026, 04, 01, 10, 00, 00, TimeSpan.Zero);
+        var videoPath = Path.Combine(Path.GetTempPath(), $"{Guid.NewGuid():N}.mp4");
+        await File.WriteAllBytesAsync(videoPath, new byte[16]);
+
+        try
+        {
+            var result = await uploader.UploadAsync(
+                new YouTubeUploadRequest(
+                    videoPath,
+                    "t",
+                    "d",
+                    ScheduledPublishAtUtc: scheduledAt),
+                _ => Task.CompletedTask,
+                CancellationToken.None);
+
+            Assert.Equal("video123", result.VideoId);
+        }
+        finally
+        {
+            File.Delete(videoPath);
+        }
+
+        Assert.NotNull(initiateJson);
+
+        using var doc = JsonDocument.Parse(initiateJson!);
+        Assert.Equal("private", doc.RootElement.GetProperty("status").GetProperty("privacyStatus").GetString());
+
+        var publishAtText = doc.RootElement.GetProperty("status").GetProperty("publishAt").GetString();
+        Assert.Equal("2026-04-01T10:00:00Z", publishAtText);
+    }
+}
+
+file sealed class StubAccessTokenProvider(string token) : IYouTubeAccessTokenProvider
+{
+    public Task<string> GetAccessTokenAsync(CancellationToken ct) => Task.FromResult(token);
+}
+
+file sealed class StaticOptionsMonitor<T>(T currentValue) : IOptionsMonitor<T>
+    where T : class
+{
+    public T CurrentValue { get; } = currentValue;
+    public T Get(string? name) => CurrentValue;
+    public IDisposable? OnChange(Action<T, string?> listener) => null;
+}
+
+file sealed class RecordingHandler(Func<HttpRequestMessage, Task<HttpResponseMessage>> responder) : HttpMessageHandler
+{
+    public int CallCount { get; private set; }
+
+    protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+    {
+        CallCount++;
+        return await responder(request);
+    }
+}
+
+file static class FormEncoding
+{
+    public static Dictionary<string, string> ParseFormUrlEncoded(string form)
+    {
+        var dict = new Dictionary<string, string>(StringComparer.Ordinal);
+        var parts = form.Split('&', StringSplitOptions.RemoveEmptyEntries);
+        foreach (var part in parts)
+        {
+            var idx = part.IndexOf('=', StringComparison.Ordinal);
+            if (idx <= 0)
+            {
+                continue;
+            }
+
+            var name = Uri.UnescapeDataString(part[..idx].Replace('+', ' '));
+            var value = Uri.UnescapeDataString(part[(idx + 1)..].Replace('+', ' '));
+            dict[name] = value;
+        }
+
+        return dict;
+    }
+}

--- a/TubePilot/TubePilot.Infrastructure/ServiceCollectionExtensions.cs
+++ b/TubePilot/TubePilot.Infrastructure/ServiceCollectionExtensions.cs
@@ -7,6 +7,8 @@ using TubePilot.Infrastructure.Drive.State;
 using TubePilot.Infrastructure.Telegram;
 using TubePilot.Infrastructure.Telegram.Options;
 using TubePilot.Infrastructure.Video;
+using TubePilot.Infrastructure.YouTube;
+using TubePilot.Infrastructure.YouTube.Options;
 
 namespace TubePilot.Infrastructure;
 
@@ -21,6 +23,12 @@ public static class ServiceCollectionExtensions
         services.Configure<TelegramOptions>(configuration.GetSection(TelegramOptions.SectionName));
         services.AddSingleton<IFfmpegRunner, FfmpegRunner>();
         services.AddSingleton<IVideoProcessor, FfmpegVideoProcessor>();
+
+        services.Configure<YouTubeOptions>(configuration.GetSection(YouTubeOptions.SectionName));
+        services.AddHttpClient();
+        services.AddHttpClient<OAuthRefreshTokenAccessTokenProvider>(client => client.Timeout = TimeSpan.FromSeconds(30));
+        services.AddSingleton<IYouTubeAccessTokenProvider>(sp => sp.GetRequiredService<OAuthRefreshTokenAccessTokenProvider>());
+        services.AddHttpClient<IYouTubeUploader, YouTubeUploader>(client => client.Timeout = Timeout.InfiniteTimeSpan);
         
         services.AddSingleton<TelegramBotService>();
         services.AddHostedService(sp => sp.GetRequiredService<TelegramBotService>());

--- a/TubePilot/TubePilot.Infrastructure/TubePilot.Infrastructure.csproj
+++ b/TubePilot/TubePilot.Infrastructure/TubePilot.Infrastructure.csproj
@@ -13,6 +13,7 @@
       <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.5" />
       <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.5" />
       <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.5" />
+      <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.5" />
       <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.5" />
       <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.5" />
       <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="10.0.5" />

--- a/TubePilot/TubePilot.Infrastructure/YouTube/OAuthRefreshTokenAccessTokenProvider.cs
+++ b/TubePilot/TubePilot.Infrastructure/YouTube/OAuthRefreshTokenAccessTokenProvider.cs
@@ -1,0 +1,92 @@
+using System.Net.Http.Headers;
+using System.Text.Json;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using TubePilot.Infrastructure.YouTube.Options;
+
+namespace TubePilot.Infrastructure.YouTube;
+
+internal interface IYouTubeAccessTokenProvider
+{
+    Task<string> GetAccessTokenAsync(CancellationToken ct);
+}
+
+internal sealed class OAuthRefreshTokenAccessTokenProvider(
+    HttpClient httpClient,
+    IOptionsMonitor<YouTubeOptions> optionsMonitor,
+    ILogger<OAuthRefreshTokenAccessTokenProvider> logger) : IYouTubeAccessTokenProvider
+{
+    private readonly SemaphoreSlim _mutex = new(1, 1);
+    private string? _accessToken;
+    private DateTimeOffset _accessTokenExpiresAtUtc;
+
+    public async Task<string> GetAccessTokenAsync(CancellationToken ct)
+    {
+        var nowUtc = DateTimeOffset.UtcNow;
+        if (_accessToken is not null && _accessTokenExpiresAtUtc > nowUtc.AddMinutes(2))
+        {
+            return _accessToken;
+        }
+
+        await _mutex.WaitAsync(ct);
+        try
+        {
+            nowUtc = DateTimeOffset.UtcNow;
+            if (_accessToken is not null && _accessTokenExpiresAtUtc > nowUtc.AddMinutes(2))
+            {
+                return _accessToken;
+            }
+
+            var options = optionsMonitor.CurrentValue;
+            if (string.IsNullOrWhiteSpace(options.ClientId) ||
+                string.IsNullOrWhiteSpace(options.ClientSecret) ||
+                string.IsNullOrWhiteSpace(options.RefreshToken))
+            {
+                throw new InvalidOperationException("YouTube OAuth2 config is missing. Provide YouTube:ClientId, YouTube:ClientSecret, YouTube:RefreshToken.");
+            }
+
+            using var request = new HttpRequestMessage(HttpMethod.Post, "https://oauth2.googleapis.com/token");
+            request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
+            request.Content = new FormUrlEncodedContent(
+            [
+                new KeyValuePair<string, string>("client_id", options.ClientId),
+                new KeyValuePair<string, string>("client_secret", options.ClientSecret),
+                new KeyValuePair<string, string>("refresh_token", options.RefreshToken),
+                new KeyValuePair<string, string>("grant_type", "refresh_token")
+            ]);
+
+            using var response = await httpClient.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, ct);
+            var responseBody = await response.Content.ReadAsStringAsync(ct);
+
+            if (!response.IsSuccessStatusCode)
+            {
+                logger.LogError(
+                    "YouTube OAuth token refresh failed: {StatusCode} {ReasonPhrase}. Body: {Body}",
+                    (int)response.StatusCode,
+                    response.ReasonPhrase,
+                    responseBody);
+
+                throw new HttpRequestException($"YouTube OAuth token refresh failed ({(int)response.StatusCode} {response.ReasonPhrase}).");
+            }
+
+            using var doc = JsonDocument.Parse(responseBody);
+            if (!doc.RootElement.TryGetProperty("access_token", out var accessTokenElement) ||
+                accessTokenElement.GetString() is not { Length: > 0 } accessToken)
+            {
+                throw new InvalidOperationException("YouTube OAuth token refresh response is missing access_token.");
+            }
+
+            var expiresInSeconds = doc.RootElement.TryGetProperty("expires_in", out var expiresInElement)
+                ? expiresInElement.GetInt32()
+                : 3600;
+
+            _accessToken = accessToken;
+            _accessTokenExpiresAtUtc = DateTimeOffset.UtcNow.AddSeconds(expiresInSeconds);
+            return accessToken;
+        }
+        finally
+        {
+            _mutex.Release();
+        }
+    }
+}

--- a/TubePilot/TubePilot.Infrastructure/YouTube/Options/YouTubeOptions.cs
+++ b/TubePilot/TubePilot.Infrastructure/YouTube/Options/YouTubeOptions.cs
@@ -1,0 +1,13 @@
+namespace TubePilot.Infrastructure.YouTube.Options;
+
+public sealed record YouTubeOptions
+{
+    public const string SectionName = "YouTube";
+
+    public string? ClientId { get; init; }
+    public string? ClientSecret { get; init; }
+    public string? RefreshToken { get; init; }
+
+    public string DefaultCategoryId { get; init; } = "22";
+    public int MaxUploadsPerDay { get; init; } = 6;
+}

--- a/TubePilot/TubePilot.Infrastructure/YouTube/README.md
+++ b/TubePilot/TubePilot.Infrastructure/YouTube/README.md
@@ -1,0 +1,46 @@
+# YouTube uploader (Issue #4)
+
+This module implements `TubePilot.Core.Contracts.IYouTubeUploader` using:
+- OAuth2 refresh token (`YouTube:ClientId`, `YouTube:ClientSecret`, `YouTube:RefreshToken`)
+- resumable uploads (chunked `PUT` with `Content-Range`)
+- optional thumbnail upload
+- scheduled publishing (`publishAt` + `privacyStatus=private`)
+
+## Config
+
+Put secrets in `TubePilot/TubePilot.Worker/secrets.json` (do not commit):
+
+```json
+{
+  "YouTube": {
+    "ClientId": "xxx.apps.googleusercontent.com",
+    "ClientSecret": "GOCSPX-xxx",
+    "RefreshToken": "1//xxx",
+    "DefaultCategoryId": "22",
+    "MaxUploadsPerDay": 6
+  }
+}
+```
+
+## Manual smoke test (code snippet)
+
+Call the uploader from any async context (e.g. a `BackgroundService`):
+
+```csharp
+var result = await youTubeUploader.UploadAsync(
+    new YouTubeUploadRequest(
+        VideoFilePath: @"C:\videos\test.mp4",
+        Title: "TubePilot test",
+        Description: "Uploaded by TubePilot",
+        Tags: ["test", "tubepilot"],
+        ScheduledPublishAtUtc: DateTimeOffset.UtcNow.AddHours(2),
+        ThumbnailFilePath: @"C:\videos\thumb.jpg"),
+    progress =>
+    {
+        logger.LogInformation("YouTube upload progress: {Percent}%", progress);
+        return Task.CompletedTask;
+    },
+    ct);
+
+logger.LogInformation("YouTube result: {Url} ({Status})", result.YouTubeUrl, result.Status);
+```

--- a/TubePilot/TubePilot.Infrastructure/YouTube/YouTubeUploader.cs
+++ b/TubePilot/TubePilot.Infrastructure/YouTube/YouTubeUploader.cs
@@ -1,0 +1,301 @@
+using System.Net.Http.Headers;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using TubePilot.Core.Contracts;
+using TubePilot.Infrastructure.YouTube.Options;
+
+namespace TubePilot.Infrastructure.YouTube;
+
+internal sealed class YouTubeUploader(
+    HttpClient httpClient,
+    IYouTubeAccessTokenProvider accessTokenProvider,
+    IOptionsMonitor<YouTubeOptions> optionsMonitor,
+    ILogger<YouTubeUploader> logger) : IYouTubeUploader
+{
+    private const int ChunkSizeBytes = 4 * 1024 * 1024;
+
+    public async Task<YouTubeUploadResult> UploadAsync(
+        YouTubeUploadRequest request,
+        Func<int, Task> progressCallback,
+        CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        ArgumentNullException.ThrowIfNull(progressCallback);
+
+        if (!File.Exists(request.VideoFilePath))
+        {
+            throw new FileNotFoundException("Video file not found.", request.VideoFilePath);
+        }
+
+        await progressCallback(0);
+
+        var accessToken = await accessTokenProvider.GetAccessTokenAsync(ct);
+        var uploadUrl = await InitiateResumableUploadAsync(request, accessToken, ct);
+        var videoId = await UploadVideoInChunksAsync(request, uploadUrl, accessToken, progressCallback, ct);
+
+        if (!string.IsNullOrWhiteSpace(request.ThumbnailFilePath))
+        {
+            await TryUploadThumbnailAsync(videoId, request.ThumbnailFilePath!, accessToken, ct);
+        }
+
+        var scheduled = request.ScheduledPublishAtUtc?.ToUniversalTime();
+        return new YouTubeUploadResult(
+            videoId,
+            $"https://www.youtube.com/watch?v={videoId}",
+            scheduled is null ? YouTubeUploadStatus.Published : YouTubeUploadStatus.Scheduled,
+            scheduled);
+    }
+
+    private async Task<Uri> InitiateResumableUploadAsync(YouTubeUploadRequest request, string accessToken, CancellationToken ct)
+    {
+        var options = optionsMonitor.CurrentValue;
+        var payload = BuildInitiatePayload(request, options);
+        var json = JsonSerializer.Serialize(payload, new JsonSerializerOptions
+        {
+            DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
+        });
+
+        var fileInfo = new FileInfo(request.VideoFilePath);
+        var contentType = GuessMimeType(request.VideoFilePath) ?? "application/octet-stream";
+
+        using var httpRequest = new HttpRequestMessage(
+            HttpMethod.Post,
+            "https://www.googleapis.com/upload/youtube/v3/videos?uploadType=resumable&part=snippet,status");
+
+        httpRequest.Headers.Authorization = new AuthenticationHeaderValue("Bearer", accessToken);
+        httpRequest.Headers.TryAddWithoutValidation("X-Upload-Content-Length", fileInfo.Length.ToString());
+        httpRequest.Headers.TryAddWithoutValidation("X-Upload-Content-Type", contentType);
+        httpRequest.Content = new StringContent(json, Encoding.UTF8, "application/json");
+
+        using var response = await httpClient.SendAsync(httpRequest, HttpCompletionOption.ResponseHeadersRead, ct);
+        var responseBody = await response.Content.ReadAsStringAsync(ct);
+        if (!response.IsSuccessStatusCode)
+        {
+            logger.LogError(
+                "YouTube resumable upload initiation failed: {StatusCode} {ReasonPhrase}. Body: {Body}",
+                (int)response.StatusCode,
+                response.ReasonPhrase,
+                responseBody);
+
+            throw new HttpRequestException($"YouTube resumable upload initiation failed ({(int)response.StatusCode} {response.ReasonPhrase}).");
+        }
+
+        if (!response.Headers.Location?.IsAbsoluteUri ?? true)
+        {
+            throw new InvalidOperationException("YouTube resumable upload initiation response is missing Location header.");
+        }
+
+        return response.Headers.Location!;
+    }
+
+    private async Task<string> UploadVideoInChunksAsync(
+        YouTubeUploadRequest request,
+        Uri uploadUrl,
+        string accessToken,
+        Func<int, Task> progressCallback,
+        CancellationToken ct)
+    {
+        await using var fileStream = new FileStream(
+            request.VideoFilePath,
+            FileMode.Open,
+            FileAccess.Read,
+            FileShare.Read,
+            bufferSize: 1024 * 64,
+            useAsync: true);
+
+        var totalBytes = fileStream.Length;
+        var bytesUploaded = 0L;
+        var lastReportedPercent = -1;
+
+        var buffer = new byte[ChunkSizeBytes];
+        while (bytesUploaded < totalBytes)
+        {
+            ct.ThrowIfCancellationRequested();
+
+            fileStream.Position = bytesUploaded;
+            var bytesRead = await fileStream.ReadAsync(buffer, 0, (int)Math.Min(buffer.Length, totalBytes - bytesUploaded), ct);
+            if (bytesRead <= 0)
+            {
+                break;
+            }
+
+            var startByte = bytesUploaded;
+            var endByte = bytesUploaded + bytesRead - 1;
+
+            using var httpRequest = new HttpRequestMessage(HttpMethod.Put, uploadUrl);
+            httpRequest.Headers.Authorization = new AuthenticationHeaderValue("Bearer", accessToken);
+
+            var chunkContent = new ByteArrayContent(buffer, 0, bytesRead);
+            chunkContent.Headers.ContentType = new MediaTypeHeaderValue(GuessMimeType(request.VideoFilePath) ?? "application/octet-stream");
+            chunkContent.Headers.ContentRange = new ContentRangeHeaderValue(startByte, endByte, totalBytes);
+            httpRequest.Content = chunkContent;
+
+            using var response = await httpClient.SendAsync(httpRequest, HttpCompletionOption.ResponseHeadersRead, ct);
+
+            if ((int)response.StatusCode == 308)
+            {
+                bytesUploaded = endByte + 1;
+
+                if (response.Headers.TryGetValues("Range", out var rangeValues))
+                {
+                    var range = rangeValues.FirstOrDefault();
+                    var lastByte = TryParseLastByteFromRangeHeader(range);
+                    if (lastByte is not null && lastByte.Value + 1 > bytesUploaded)
+                    {
+                        bytesUploaded = lastByte.Value + 1;
+                    }
+                }
+
+                lastReportedPercent = await ReportProgressAsync(bytesUploaded, totalBytes, progressCallback, lastReportedPercent);
+                continue;
+            }
+
+            var responseBody = await response.Content.ReadAsStringAsync(ct);
+            if (!response.IsSuccessStatusCode)
+            {
+                logger.LogError(
+                    "YouTube resumable upload chunk failed: {StatusCode} {ReasonPhrase}. Body: {Body}",
+                    (int)response.StatusCode,
+                    response.ReasonPhrase,
+                    responseBody);
+
+                throw new HttpRequestException($"YouTube upload failed ({(int)response.StatusCode} {response.ReasonPhrase}).");
+            }
+
+            using var doc = JsonDocument.Parse(responseBody);
+            if (!doc.RootElement.TryGetProperty("id", out var idElement) ||
+                idElement.GetString() is not { Length: > 0 } videoId)
+            {
+                throw new InvalidOperationException("YouTube upload response is missing video id.");
+            }
+
+            bytesUploaded = totalBytes;
+            await progressCallback(100);
+            return videoId;
+        }
+
+        throw new InvalidOperationException("YouTube upload ended unexpectedly before completion.");
+    }
+
+    private async Task TryUploadThumbnailAsync(string videoId, string thumbnailFilePath, string accessToken, CancellationToken ct)
+    {
+        if (!File.Exists(thumbnailFilePath))
+        {
+            logger.LogWarning("Thumbnail file not found: {ThumbnailFilePath}", thumbnailFilePath);
+            return;
+        }
+
+        await using var stream = new FileStream(thumbnailFilePath, FileMode.Open, FileAccess.Read, FileShare.Read, 1024 * 64, useAsync: true);
+
+        var url = $"https://www.googleapis.com/upload/youtube/v3/thumbnails/set?videoId={Uri.EscapeDataString(videoId)}&uploadType=media";
+        using var httpRequest = new HttpRequestMessage(HttpMethod.Post, url);
+        httpRequest.Headers.Authorization = new AuthenticationHeaderValue("Bearer", accessToken);
+
+        var content = new StreamContent(stream);
+        content.Headers.ContentType = new MediaTypeHeaderValue(GuessMimeType(thumbnailFilePath) ?? "application/octet-stream");
+        httpRequest.Content = content;
+
+        using var response = await httpClient.SendAsync(httpRequest, HttpCompletionOption.ResponseHeadersRead, ct);
+        var responseBody = await response.Content.ReadAsStringAsync(ct);
+        if (!response.IsSuccessStatusCode)
+        {
+            logger.LogError(
+                "YouTube thumbnail upload failed: {StatusCode} {ReasonPhrase}. Body: {Body}",
+                (int)response.StatusCode,
+                response.ReasonPhrase,
+                responseBody);
+        }
+    }
+
+    private static object BuildInitiatePayload(YouTubeUploadRequest request, YouTubeOptions options)
+    {
+        var scheduledUtc = request.ScheduledPublishAtUtc?.UtcDateTime;
+        var privacyStatus = scheduledUtc is null ? "public" : "private";
+        var categoryId = string.IsNullOrWhiteSpace(request.CategoryId) ? options.DefaultCategoryId : request.CategoryId;
+
+        return new
+        {
+            snippet = new
+            {
+                title = request.Title,
+                description = request.Description,
+                tags = request.Tags,
+                categoryId
+            },
+            status = new
+            {
+                privacyStatus,
+                publishAt = scheduledUtc,
+                selfDeclaredMadeForKids = false
+            }
+        };
+    }
+
+    private static async Task<int> ReportProgressAsync(
+        long bytesUploaded,
+        long totalBytes,
+        Func<int, Task> progressCallback,
+        int lastReportedPercent)
+    {
+        if (totalBytes <= 0)
+        {
+            return lastReportedPercent;
+        }
+
+        var percent = (int)Math.Floor(bytesUploaded * 100d / totalBytes);
+        if (percent >= 100)
+        {
+            percent = 99;
+        }
+
+        if (percent == lastReportedPercent)
+        {
+            return lastReportedPercent;
+        }
+
+        await progressCallback(percent);
+        return percent;
+    }
+
+    private static long? TryParseLastByteFromRangeHeader(string? rangeHeader)
+    {
+        if (string.IsNullOrWhiteSpace(rangeHeader))
+        {
+            return null;
+        }
+
+        // Example: "bytes=0-1048575"
+        var equalsIndex = rangeHeader.IndexOf('=', StringComparison.Ordinal);
+        if (equalsIndex < 0 || equalsIndex == rangeHeader.Length - 1)
+        {
+            return null;
+        }
+
+        var dashIndex = rangeHeader.IndexOf('-', equalsIndex + 1);
+        if (dashIndex < 0 || dashIndex == rangeHeader.Length - 1)
+        {
+            return null;
+        }
+
+        var lastByteText = rangeHeader[(dashIndex + 1)..].Trim();
+        return long.TryParse(lastByteText, out var lastByte) ? lastByte : null;
+    }
+
+    private static string? GuessMimeType(string path)
+    {
+        var ext = Path.GetExtension(path).ToLowerInvariant();
+        return ext switch
+        {
+            ".mp4" => "video/mp4",
+            ".mov" => "video/quicktime",
+            ".mkv" => "video/x-matroska",
+            ".webm" => "video/webm",
+            ".jpg" or ".jpeg" => "image/jpeg",
+            ".png" => "image/png",
+            _ => null
+        };
+    }
+}


### PR DESCRIPTION
Closes #4

Implements `IYouTubeUploader` with OAuth2 refresh-token auth and resumable chunked upload. Supports upload-now (public), scheduled publish (publishAt + private), and optional thumbnail upload. Adds unit tests for token refresh and scheduled request payload, plus a manual smoke-test snippet in the YouTube module README.

Tested: `dotnet test TubePilot/TubePilot.sln`